### PR TITLE
fixed current year month generation bug and fixed header on APOD

### DIFF
--- a/apod.html
+++ b/apod.html
@@ -5,10 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SCCRM | APOD</title>
-
-    <link rel="stylesheet" href="assets/css/cam.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
+    <link rel="stylesheet" href="assets/css/cam.css">
     <link rel="stylesheet" href="assets/css/apod.css">
 </head>
 
@@ -17,9 +16,7 @@
         <nav id="navbar" class="navbar navbar-expand-lg ">
             <a class="navbar-brand" href="developed-by.html">
                 <div class="logo-image logo-container">
-                    <img src="assets/images/image_720.png" class="img-fluid" id="logo">
-                    <p id="team">Team </p>
-                    <p id="SCCRM">SCCRM</p>
+                    <img src="assets/images/logo2" class="img-fluid" id="logo">
                 </div>
             </a>
             <div class="container-fluid ">

--- a/assets/js/apod.js
+++ b/assets/js/apod.js
@@ -52,7 +52,8 @@ monthSelectEl.addEventListener('click', () => { // populates month
         } else { return }
     // second, check for current year
     } else if (yearSelectEl.value === currentYear) {
-        if (monthSelectEl.length !== Number(currentMonthNumbers)) {
+        var tempNum = Number(currentMonthNumbers)+1 // need the length +1 to include the option with 'Month'
+        if (monthSelectEl.length !== Number(tempNum)) {
             dynamicMonths(0, Number(currentMonthNumbers))
         } else { return }
     // all other months will just have all 12 months


### PR DESCRIPTION
Found the bug causing current year month generation to not work. I had the length off by one because I forgot to include for the extra option of 'Month.'

I also updated the header on APOD to match the homepage.